### PR TITLE
Fix share button copying a link to undefined

### DIFF
--- a/pages/[year]/index.vue
+++ b/pages/[year]/index.vue
@@ -171,7 +171,7 @@ const share = async (result) => {
     navigator.share(shareData);
   } else {
     await navigator.clipboard.writeText(
-      `https://frctools.com/${year.value.value}/rule/${result.name}`
+      `https://frctools.com/${year.value}/rule/${result.name}`
     );
   }
 };


### PR DESCRIPTION
Clicking the share button on a rule (assuming the navigator cannot share and will instead copy to clipboard) currently copies a link to the year "undefined" to the clipboard. For example: `https://frctools.com/undefined/rule/G212`.

The expression in the template string `${year.value.value}` is getting the value field twice, which is not defined once the String value is retrieved the first time.

`year` -> `{ value: "2025", ...}`
`year.value` -> `"2025"`
`year.value.value` -> `undefined`